### PR TITLE
fix "global name 'app_token_url_template' is not defined"

### DIFF
--- a/usergrid/UsergridAuth.py
+++ b/usergrid/UsergridAuth.py
@@ -18,6 +18,7 @@
 import json
 import requests
 from usergrid.management_templates import org_token_url_template
+from usergrid.app_templates import app_token_url_template
 
 
 class UsergridAuth:


### PR DESCRIPTION
I tried using the client slightly differently to your example, more like:

```
client = usergrid.UsergridClient(
    org_id=org_id,
    app_id=app_id,
    client_id=client_id,
    client_secret=client_secret
)

client.PUT(...etc...)
```

... and that symbol was missing.  So I imported it and now everything seems to work!
